### PR TITLE
[cgroupv2_freeze] 优化 cgroup 挂载脚本

### DIFF
--- a/cgroupv2_freeze/cgroupv2_freeze.c
+++ b/cgroupv2_freeze/cgroupv2_freeze.c
@@ -388,7 +388,8 @@ static void do_filp_open_after(hook_fargs3_t* args, void* udata) {
   else\
     exit;\
   fi;\
-\
+fi;\
+if [ ! -d \"/sys/fs/cgroup/frozen\" ] && [ -f \"/sys/fs/cgroup/uid_0/cgroup.freeze\" ]; then\
   mkdir /sys/fs/cgroup/frozen/;\
   chown -R system:system /sys/fs/cgroup/frozen/;\
   echo 1 > /sys/fs/cgroup/frozen/cgroup.freeze;\


### PR DESCRIPTION
我手机系统是安卓14的crdroid，它好像会自动挂载cgroup，导致frozen没有初始化，所以改了一下脚本